### PR TITLE
Update popular products layout

### DIFF
--- a/client/src/pages/Products.tsx
+++ b/client/src/pages/Products.tsx
@@ -325,14 +325,18 @@ export default function Products() {
             ) : (
               <>
                 <h2 className="text-xl font-bold mb-4">🔥 인기상품</h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
-                  {popularProducts.map((product) => (
-                    <ProductCard
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+                  {popularProducts.slice(0, 3).map((product) => (
+                    <div
                       key={product.id}
-                      product={product}
-                      onAddToCart={handleAddToCart}
-                      onToggleFavorite={handleToggleFavorite}
-                    />
+                      className="rounded-xl overflow-hidden shadow-md bg-white h-[270px]"
+                    >
+                      <img
+                        src={product.imageUrl}
+                        alt={language === "ko" ? product.nameKo : product.name}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
                   ))}
                 </div>
                 <h2 className="text-xl font-bold mb-4">📦 전체 상품</h2>


### PR DESCRIPTION
## Summary
- streamline layout of the popular products section
- show first three featured products as simple image cards
- keep remaining products in list style

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6875f3d4021883269bdb0fc6c066f5ee