### PR TITLE
Fix popular products layout

### DIFF
--- a/client/src/pages/Products.tsx
+++ b/client/src/pages/Products.tsx
@@ -113,7 +113,7 @@ export default function Products() {
     }
   });
 
-  const popularProducts = (sortedProducts ?? []).filter(p => p.isFeatured).slice(0, 3);
+  const popularProducts = (sortedProducts ?? []).filter(p => p.isFeatured);
   const otherProducts = (sortedProducts ?? []).filter(p => !p.isFeatured);
 
   return (
@@ -325,18 +325,23 @@ export default function Products() {
             ) : (
               <>
                 <h2 className="text-xl font-bold mb-4">🔥 인기상품</h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                   {popularProducts.slice(0, 3).map((product) => (
                     <div
                       key={product.id}
                       className="rounded-xl overflow-hidden shadow-md bg-white h-[270px]"
                     >
                       <img
-                        src={product.imageUrl}
+                        src={product.imageUrl || '/placeholder.png'}
                         alt={language === "ko" ? product.nameKo : product.name}
                         className="w-full h-full object-cover"
                       />
                     </div>
+                  ))}
+                </div>
+                <div className="space-y-4 mt-8">
+                  {popularProducts.slice(3).map((product) => (
+                    <ProductListItem key={product.id} product={product} />
                   ))}
                 </div>
                 <h2 className="text-xl font-bold mb-4">📦 전체 상품</h2>


### PR DESCRIPTION
## Summary
- fix the popular product section to show first 3 as image-only boxes
- list remaining featured products below images
- show placeholder image when no product image

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_687601d1e54c8326a33ff05ddc24e0b8